### PR TITLE
Ensure valid COGs are saved implicitly, formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.formatting.provider": "autopep8",
+    "python.analysis.typeCheckingMode": "off"
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,12 +34,14 @@ install_requires =
     pyproj
     grass-session
     dask
+    dask-image
     numpy
     scikit-image
     scikit-learn
     numba
     fiona
     shapely
+    matplotlib
 
 [options.packages.find]
 where = src

--- a/src/hydrotools/__init__.py
+++ b/src/hydrotools/__init__.py
@@ -1,3 +1,2 @@
-
 __version__ = "0.1.0"
 """Library version"""

--- a/src/hydrotools/config.py
+++ b/src/hydrotools/config.py
@@ -13,17 +13,7 @@ GRASS_FLAGS: dict = {"quiet": True}
 
 GDAL_DEFAULT_ARGS = [
     "-of",
-    "GTiff",
-    "-co",
-    "COPY_SRC_OVERVIEWS=YES",
-    "-co",
-    "TILED=YES",
-    "-co",
-    "COMPRESS=LZW",
-    "-co",
-    "BLOCKXSIZE=512",
-    "-co",
-    "BLOCKYSIZE=512",
+    "COG",
     "-co",
     "BIGTIFF=YES",
     "-q",

--- a/src/hydrotools/interpolate.py
+++ b/src/hydrotools/interpolate.py
@@ -54,7 +54,6 @@ def raster_filter(
 
         for i in range(i_start, a.shape[1] - i_end):
             for j in range(j_start, a.shape[2] - j_end):
-
                 if np.isnan(a[0, i, j]):
                     continue
 
@@ -829,7 +828,7 @@ def normalize(
     )
 
     if invert:
-        norm = 1. - norm
+        norm = 1.0 - norm
 
     out_rast = norm * (out_max - out_min) + out_min
 

--- a/src/hydrotools/utils.py
+++ b/src/hydrotools/utils.py
@@ -265,7 +265,7 @@ def kernel_from_distance(distance: float, csx: float, csy: float) -> np.ndarray:
 
     kernel = np.ones(shape=(int(num_cells_y), int(num_cells_x)), dtype=bool)
     kernel[centroid] = 0
-    
+
     dt = distance_transform_edt(kernel, (csy, csx))
 
     return dt <= distance

--- a/src/hydrotools/watershed.py
+++ b/src/hydrotools/watershed.py
@@ -167,7 +167,7 @@ def stream_order(
     order_dst: str,
     use_accum: bool = False,
     zero_bg: bool = False,
-    memory: Union[int, None] = 4096
+    memory: Union[int, None] = 4096,
 ):
     """Calculate stream order using the following data:
 


### PR DESCRIPTION
* Change the default GDAL args to use the COG driver
* Use COGs by default when using `Raster.to_raster`, which increases runtime due to double-saving. Set to `false` in relevant sections where rasters are temporary or not returned from functions.
* `black` formatting
* Add missing packages in `setup.cfg`